### PR TITLE
Load Supabase config from env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Local environment variables
+
+js/env.js
+

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,7 +5,7 @@
 1. **Supabase Configuration**
    - Create a new project at https://supabase.com
    - Copy your project URL and anon key
-   - Update `js/config.js` with your credentials
+   - Duplicate `js/env.example.js` as `js/env.js` and add your credentials. This file is ignored by git.
 
 2. **Database Setup**
    - Run the SQL schema from `README.md` in your Supabase SQL editor

--- a/README.md
+++ b/README.md
@@ -33,14 +33,15 @@ A Progressive Web App (PWA) for Valley Creek Church staff to track and manage in
 
 1. Create a new Supabase project at [supabase.com](https://supabase.com)
 2. Get your project URL and anon key from the API settings
-3. Update `/js/config.js` with your Supabase credentials:
+3. Copy `js/env.example.js` to `js/env.js` and add your credentials:
 
 ```javascript
-const SUPABASE_CONFIG = {
-    url: 'YOUR_SUPABASE_URL',
-    anonKey: 'YOUR_SUPABASE_ANON_KEY'
+window.env = {
+  SUPABASE_URL: 'https://your-project.supabase.co',
+  SUPABASE_ANON_KEY: 'YOUR_ANON_KEY'
 };
 ```
+   *`js/env.js` is excluded from version control so your keys remain private.*
 
 ### 2. Database Schema
 

--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
     </div>
     
     <!-- Scripts -->
+    <script src="/js/env.js"></script>
     <script src="/js/config.js?v=4"></script>
     <script src="/js/auth.js?v=4"></script>
     <script src="/js/router.js?v=4"></script>

--- a/js/config.js
+++ b/js/config.js
@@ -1,8 +1,8 @@
 // Supabase Configuration
-// Updated with correct project credentials
+// Credentials are loaded from window.env which should be defined in js/env.js
 const SUPABASE_CONFIG = {
-    url: 'https://pvjdsfhhcugnrzmibhab.supabase.co',
-    anonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InB2amRzZmhoY3VnbnJ6bWliaGFiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM3MDQwNjEsImV4cCI6MjA2OTI4MDA2MX0.LXgde3rzdPLmfycDQW2Rf1nJ9qKMUBr2J6Yh1ZGp3Ic'
+    url: window.env?.SUPABASE_URL || '',
+    anonKey: window.env?.SUPABASE_ANON_KEY || ''
 };
 
 // Initialize Supabase client
@@ -10,6 +10,10 @@ let supabaseClient;
 
 // Function to initialize Supabase when library is ready
 function initializeSupabase() {
+    if (!SUPABASE_CONFIG.url || !SUPABASE_CONFIG.anonKey) {
+        console.error('Supabase credentials missing. Define SUPABASE_URL and SUPABASE_ANON_KEY in js/env.js');
+        return false;
+    }
     console.log('Attempting to initialize Supabase...');
     console.log('Config URL:', SUPABASE_CONFIG.url);
     console.log('Config Key (first 20 chars):', SUPABASE_CONFIG.anonKey.substring(0, 20) + '...');

--- a/js/env.example.js
+++ b/js/env.example.js
@@ -1,0 +1,4 @@
+window.env = {
+  SUPABASE_URL: 'https://your-project.supabase.co',
+  SUPABASE_ANON_KEY: 'YOUR_ANON_KEY'
+};


### PR DESCRIPTION
## Summary
- load Supabase URL and anon key from `window.env`
- add example env file and ignore real one
- include env.js in index.html
- update docs for new configuration approach

## Testing
- `node -v`
- `npm install @supabase/supabase-js` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6887b9e31e3c832888c3b2c54749e92c